### PR TITLE
Fix problems with dependency generation

### DIFF
--- a/src/main/groovy/com/iadams/gradle/plugins/tasks/PackagePluginTask.groovy
+++ b/src/main/groovy/com/iadams/gradle/plugins/tasks/PackagePluginTask.groovy
@@ -133,7 +133,20 @@ class PackagePluginTask extends Jar {
         if(!getSkipDependenciesPackaging()) {
 
             List<ResolvedDependency> dependencies = new DependencyQuery(project).getNotProvidedDependencies()
-            manifest.attributes.put(PluginManifest.DEPENDENCIES, dependencies.collect{ "META-INF/lib/${it.moduleName}:${it.moduleVersion}.jar" }.join(' '))
+
+            final List<String> deps = new ArrayList<>();
+            String depname;
+            String classifier;
+
+            for (final ResolvedDependency dependency: dependencies) {
+                depname = dependency.moduleName + '-' + dependency.moduleVersion;
+                classifier = dependency.moduleArtifacts.iterator().next().classifier;
+                if (classifier != null)
+                    depname += '-' + classifier;
+                deps.add(depname + ".jar");
+            }
+
+            manifest.attributes.put(PluginManifest.DEPENDENCIES, deps.collect{ "META-INF/lib/${it}" }.join(' '))
 
             if(dependencies.size()>0){
                 logger.info "Following dependencies are packaged in the plugin:\n"


### PR DESCRIPTION
- The Plugin-Dependencies manifest entry uses the dash (-) and not the colon (:)
  to separate the name from the version. Fixed.
- Dependencies with classifiers would be renamed by the Maven plugin; here the
  name remains intact. Grab the classifier, if any, and append it to the
  artifact-version pair before appending .jar.

Fixes for issue #1. Not perfect however.
