### PR TITLE
Search plugin class in all output classes directories

### DIFF
--- a/src/main/groovy/com/iadams/gradle/plugins/tasks/PackagePluginTask.groovy
+++ b/src/main/groovy/com/iadams/gradle/plugins/tasks/PackagePluginTask.groovy
@@ -207,7 +207,11 @@ class PackagePluginTask extends Jar {
   }
 
   private void checkPluginClass() throws GradleException {
-    if (!new File(project.sourceSets.main.output.classesDir, getPluginClass().replace('.', '/') + ".class").exists()) {
+    String pluginClassPath = getPluginClass().replace('.', '/') + ".class";
+    boolean pluginClassExists = project.sourceSets.main.output.classesDirs.files
+            .collect { file -> file.toPath().resolve(pluginClassPath).toFile().exists() }
+            .any()
+    if (!pluginClassExists) {
       throw new GradleException("Plugin class not found: " + getPluginClass())
     }
   }


### PR DESCRIPTION
`checkPluginClass` used deprecated `classesDir`, which resolved to a single directory (e.g. 'build/classes/java/').
See the deprecation: https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/SourceSetOutput.html

This commit uses `classesDirs`, which is a file collection with all configured output classes (e.g. 'build/classes/java/' and 'build/classes/kotlin/').

Fixes #20